### PR TITLE
refactor: allow build scripts via package.json instead of pnpm-workspace.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .tanstack
+.wrangler

--- a/package.json
+++ b/package.json
@@ -53,5 +53,13 @@
     "vite-plugin-svgr": "^4.5.0",
     "vitest": "^4.1.2",
     "wrangler": "^4.80.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "supabase",
+      "workerd"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,0 @@
-
-packages: [ "." ]
-allowBuilds:
-  esbuild: true
-  sharp: true
-  supabase: true
-  workerd: true


### PR DESCRIPTION
Allowing scripts via pnpm approve-builds command automatically generates a pnpm-workspace.yaml file, even if it is not a monorepo. This PR moves the allowed scripts list to package.json instead, and deletes pnpm-workspace.yaml.